### PR TITLE
Monad instance for Gen

### DIFF
--- a/src/main/scala/com/ambiata/disorder/GenPlus.scala
+++ b/src/main/scala/com/ambiata/disorder/GenPlus.scala
@@ -3,6 +3,8 @@ package com.ambiata.disorder
 import org.scalacheck._, Arbitrary._, Gen._
 import scala.collection.JavaConverters._
 
+import scalaz._, Scalaz._
+
 object GenPlus {
 
   def chooseInt(from: Int, to: Int): Gen[Int] =
@@ -54,4 +56,11 @@ object GenPlus {
     r <- checkGen(a, label, check)
   } yield r
 
+  implicit def GenMonad: Monad[Gen] = new Monad[Gen] {
+
+    def point[A](a: => A): Gen[A] = Gen.const(a)
+
+    def bind[A, B](fa: Gen[A])(f: A => Gen[B]): Gen[B] = fa.flatMap(f)
+
+  }
 }


### PR DESCRIPTION
code /ht @etorreborre 

Feel like this is probably something that would/should have been done many times over, so would be happy to be pointed to that.

Or if we want to have a function like (excuse my dodgy Scalaskell): `def scalazMonad[M](forall A. A => M[A]): Monad[M]` in some other lib and have `GenMonad = scalazMonad(Gen.const)` also let me know